### PR TITLE
LoadMap sets the env from a map

### DIFF
--- a/cmd/configu/main.go
+++ b/cmd/configu/main.go
@@ -10,7 +10,7 @@ import (
 // For custom builds, the version can be overwritten with ldflags, see
 // "Golang compile environment variable into binary"
 // https://stackoverflow.com/a/47665780/639133
-var version string = "v0.15.2"
+var version string = "v0.16.0"
 
 func main() {
 	logutil.SetupLogger(true)

--- a/pkg/cmdconfig/config_test.go
+++ b/pkg/cmdconfig/config_test.go
@@ -894,3 +894,14 @@ func TestGetEnvs(t *testing.T) {
 	is.NoErr(err)
 	is.Equal([]string{"sample.dev", "sample.prod", "sample.stage-ec2"}, envs)
 }
+
+func TestLoadMap(t *testing.T) {
+	is := testutil.Setup(t)
+
+	key := "APP_BAR"
+	os.Setenv(key, "xxx")
+
+	conf := config.LoadMap(map[string]string{key: t.Name()})
+	is.Equal(conf.Bar(), t.Name())
+	is.Equal(os.Getenv(key), t.Name())
+}

--- a/pkg/cmdconfig/templates.go
+++ b/pkg/cmdconfig/templates.go
@@ -123,11 +123,11 @@ func (c *Config) GetMap() map[string]string {
 }
 
 // LoadMap sets the env from a map and returns a new instance of Config
-func LoadMap(configMap map[string]string) conf *Config  {
+func LoadMap(configMap map[string]string) (conf *Config)  {
 	for key, val := range configMap {
 		_ = os.Setenv(key, val)
 	}
-	return New(), nil
+	return New()
 }
 
 // SetEnvBase64 decodes and sets env from the given base64 string

--- a/pkg/cmdconfig/templates.go
+++ b/pkg/cmdconfig/templates.go
@@ -122,6 +122,14 @@ func (c *Config) GetMap() map[string]string {
 	return m
 }
 
+// LoadMap sets the env from a map and returns a new instance of Config
+func LoadMap(configMap map[string]string) conf *Config  {
+	for key, val := range configMap {
+		_ = os.Setenv(key, val)
+	}
+	return New(), nil
+}
+
 // SetEnvBase64 decodes and sets env from the given base64 string
 func SetEnvBase64(configBase64 string) (err error) {
 	// Decode base64
@@ -192,8 +200,6 @@ func LoadFile(env string) (conf *Config, err error) {
 	}
 	return New(), nil
 }
-
-// LoadMap sets the env from a map and returns a new instance of Config
 `
 
 // templateTemplateGo text template to generate FileNameTemplateGo

--- a/pkg/cmdconfig/templates.go
+++ b/pkg/cmdconfig/templates.go
@@ -192,6 +192,8 @@ func LoadFile(env string) (conf *Config, err error) {
 	}
 	return New(), nil
 }
+
+// LoadMap sets the env from a map and returns a new instance of Config
 `
 
 // templateTemplateGo text template to generate FileNameTemplateGo

--- a/pkg/cmdconfig/testdata/config.go
+++ b/pkg/cmdconfig/testdata/config.go
@@ -30,7 +30,7 @@ var dir string
 
 // Config fields correspond to config file keys less the prefix
 type Config struct {
-	
+
 	bar string // APP_BAR
 	buz string // APP_BUZ
 	foo string // APP_FOO
@@ -101,76 +101,84 @@ func New() *Config {
 
 // SetVars sets non-empty package vars on Config
 func SetVars(conf *Config) {
-	
+
 	if bar != "" {
 		conf.bar = bar
 	}
-	
+
 	if buz != "" {
 		conf.buz = buz
 	}
-	
+
 	if foo != "" {
 		conf.foo = foo
 	}
-	
+
 	if templateFiz != "" {
 		conf.templateFiz = templateFiz
 	}
-	
+
 	if dir != "" {
 		conf.dir = dir
 	}
-	
+
 }
 
 // SetEnv sets non-empty env vars on Config
 func SetEnv(conf *Config) {
 	var v string
 
-	
+
 	v = os.Getenv("APP_BAR")
 	if v != "" {
 		conf.bar = v
 	}
-	
+
 	v = os.Getenv("APP_BUZ")
 	if v != "" {
 		conf.buz = v
 	}
-	
+
 	v = os.Getenv("APP_FOO")
 	if v != "" {
 		conf.foo = v
 	}
-	
+
 	v = os.Getenv("APP_TEMPLATE_FIZ")
 	if v != "" {
 		conf.templateFiz = v
 	}
-	
+
 	v = os.Getenv("APP_DIR")
 	if v != "" {
 		conf.dir = v
 	}
-	
+
 }
 
 // GetMap of all env vars
 func (c *Config) GetMap() map[string]string {
 	m := make(map[string]string)
-	
+
 	m["APP_BAR"] = c.bar
-	
+
 	m["APP_BUZ"] = c.buz
-	
+
 	m["APP_FOO"] = c.foo
-	
+
 	m["APP_TEMPLATE_FIZ"] = c.templateFiz
-	
+
 	m["APP_DIR"] = c.dir
-	
+
 	return m
+}
+
+// LoadMap sets the env from a map and returns a new instance of Config
+func LoadMap(configMap map[string]string) (conf *Config)  {
+	for key, val := range configMap {
+		_ = os.Setenv(key, val)
+	}
+	return New()
 }
 
 // SetEnvBase64 decodes and sets env from the given base64 string


### PR DESCRIPTION
`LoadMap` is useful when importing library packages with generated config that overlap the current module's config. 

For example
```go
import (
  "module/config"
  libConfig "lib/config"
  "lib/feature"
)

...
// Module config is generated in module/config
conf, _ := LoadFile("dev")
libConf := libConfig.LoadMap(conf.GetMap())
// Library method requires config that was generated in lib/config
feature.LibFunc(libConf)
```

Consider
- *"module/config"* has some keys that overlap with  *"lib/config"*
- `libConfig.LoadMap` only reads the keys that it knows about, doesn't err on empty values
- assuming `feature.LibFunc` will validate values for the keys used in the lib

